### PR TITLE
Fix SVG imports

### DIFF
--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -1,5 +1,5 @@
 ---
-import FabrSvg from '../assets/fabr.svg?component';
+import FabrSvg from '../assets/fabr.svg';
 
 ---
 

--- a/website/src/components/HeroSection.astro
+++ b/website/src/components/HeroSection.astro
@@ -1,5 +1,5 @@
 ---
-import HeroZigZagSvg from '../assets/hero-zigzag.svg?component';
+import HeroZigZagSvg from '../assets/hero-zigzag.svg';
 import { Code } from '@astrojs/starlight/components';
 ---
 

--- a/website/src/components/Navbar.astro
+++ b/website/src/components/Navbar.astro
@@ -1,6 +1,6 @@
 ---
 import { Icon } from '@astrojs/starlight/components';
-import FabrSvg from '../assets/fabr.svg?component';
+import FabrSvg from '../assets/fabr.svg';
 import ThemeSelector from './ThemeSelector.astro';
 
 ---

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -3,7 +3,7 @@ import Layout from '../layouts/Layout.astro';
 import Navbar from '../components/Navbar.astro';
 import HeroSection from '../components/HeroSection.astro';
 import CalloutSection from '../components/CalloutSection.astro';
-import SquigglySeparatorSvg from '../assets/squiggly-separator.svg?component';
+import SquigglySeparatorSvg from '../assets/squiggly-separator.svg';
 import FrameworksSection from '../components/FrameworksSection.astro';
 import ContributeSection from '../components/ContributeSection.astro';
 import Footer from '../components/Footer.astro';


### PR DESCRIPTION
Earlier SVG imports used `?component` query parameter to use SVG as component

But this is not needed as direct imports work as Astro components & adding the parameter actually breaks the import

closes #17