### PR TITLE
Add version command to display CLI version information

### DIFF
--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -19,9 +19,11 @@ export function showGlobalHelp(): void {
 	console.log(chalk.white('Available Commands:'))
 	console.log(chalk.cyan('  init') + chalk.gray('    Create a new project from a template'))
 	console.log(chalk.cyan('  list') + chalk.gray('    List all available templates'))
+	console.log(chalk.cyan('  version') + chalk.gray(' Show version information'))
 	console.log(chalk.cyan('  help') + chalk.gray('    Show this help message\n'))
 	console.log(chalk.white('Global Options:'))
-	console.log(chalk.cyan('  --help, -h') + chalk.gray('  Show help for any command\n'))
+	console.log(chalk.cyan('  --help, -h') + chalk.gray('     Show help for any command'))
+	console.log(chalk.cyan('  --version, -v') + chalk.gray('  Show version information\n'))
 	console.log(chalk.white('Examples:'))
 	console.log(
 		chalk.gray('  npx fabr init                              ') + chalk.dim('# Interactive mode'),
@@ -33,6 +35,8 @@ export function showGlobalHelp(): void {
 		chalk.gray('  npx fabr init my-project --template=slug   ') + chalk.dim('# Specify both'),
 	)
 	console.log(chalk.gray('  npx fabr list'))
+	console.log(chalk.gray('  npx fabr version'))
+	console.log(chalk.gray('  npx fabr --version'))
 	console.log(chalk.gray('  npx fabr help\n'))
 }
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -2,6 +2,7 @@ import { Template } from '../types/templates.js'
 import { InitCommand } from './init.js'
 import { HelpCommand } from './help.js'
 import { ListCommand } from './list.js'
+import { VersionCommand } from './version.js'
 import chalk from 'chalk'
 import { BaseSubcommand } from '../types/subcommand.js'
 
@@ -15,6 +16,7 @@ export interface CommandDefinition {
 const initCommand = new InitCommand()
 const listCommand = new ListCommand()
 const helpCommand = new HelpCommand()
+const versionCommand = new VersionCommand()
 
 /**
  * Registry of all available commands
@@ -34,6 +36,11 @@ export const commands: Record<string, CommandDefinition> = {
 		name: 'help',
 		description: 'Show this help message',
 		handler: helpCommand,
+	},
+	version: {
+		name: 'version',
+		description: 'Show version information',
+		handler: versionCommand,
 	},
 }
 

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -17,7 +17,7 @@ function getVersion(): string {
 		// Get the current file's directory
 		const __filename = fileURLToPath(import.meta.url)
 		const __dirname = dirname(__filename)
-		
+
 		// Go up to the project root and read package.json
 		const packagePath = join(__dirname, '../../package.json')
 		const packageData = JSON.parse(readFileSync(packagePath, 'utf-8'))

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -1,0 +1,92 @@
+import chalk from 'chalk'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { dirname, join } from 'path'
+import { parseSubcommandArgs, parseSubcommandOnlyArgs } from '../lib/args.js'
+import { HelpContent } from '../lib/help.js'
+import { BaseSubcommand, SubcommandArgs } from '../types/subcommand.js'
+
+type VersionArgs = SubcommandArgs
+
+/**
+ * Get the version from package.json
+ * @returns {string} The version string
+ */
+function getVersion(): string {
+	try {
+		// Get the current file's directory
+		const __filename = fileURLToPath(import.meta.url)
+		const __dirname = dirname(__filename)
+		
+		// Go up to the project root and read package.json
+		const packagePath = join(__dirname, '../../package.json')
+		const packageData = JSON.parse(readFileSync(packagePath, 'utf-8'))
+		return packageData.version
+	} catch (error) {
+		console.error('Error reading version:', error)
+		return 'unknown'
+	}
+}
+
+/**
+ * Show version information for the Fabr CLI.
+ * Displays the current version number.
+ *
+ * @returns {void}
+ */
+export function showVersion(): void {
+	const version = getVersion()
+	console.log(chalk.cyan.bold(`Fabr v${version}`))
+}
+
+/**
+ * Show version information for the CLI
+ */
+export class VersionCommand extends BaseSubcommand<VersionArgs> {
+	readonly name = 'version'
+	readonly description = 'Show version information'
+
+	/**
+	 * Get help content configuration for the version command.
+	 * Returns usage instructions, description, and examples specific to the version command.
+	 *
+	 * @returns {HelpContent} Help content object with usage, description, and examples
+	 *
+	 * @protected
+	 */
+	protected getHelpContent(): HelpContent {
+		return {
+			usage: 'npx fabr version',
+			description: this.description,
+			examples: [{ command: 'npx fabr version', description: 'Show current version' }],
+		}
+	}
+
+	/**
+	 * Parse command line arguments for the version command.
+	 * Extracts and validates arguments specific to the version command.
+	 *
+	 * @param {string[]} rawArgs - Raw command line arguments
+	 *
+	 * @returns {VersionArgs} Parsed version command arguments
+	 */
+	parseArgs(rawArgs: string[]): VersionArgs {
+		const cleanArgs = parseSubcommandArgs(rawArgs, this.name)
+		const parsed = parseSubcommandOnlyArgs(cleanArgs)
+
+		return {
+			help: parsed.help,
+		}
+	}
+
+	/**
+	 * Execute the version command.
+	 * Displays version information and exits the process.
+	 *
+	 * @returns {Promise<void>} A promise that resolves when version is displayed
+	 */
+	async execute(): Promise<void> {
+		showVersion()
+		process.exit(0)
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 // Import types
 import { executeCommand } from './commands/index.js'
 import { TemplatesConfig, validateTemplatesConfig } from './types/templates.js'
+import { showVersion } from './commands/version.js'
 
 // Load the list of available templates
 import templatesData from './templates.json' with { type: 'json' }
@@ -25,6 +26,12 @@ const templates = templatesConfig.templates
  */
 async function main(): Promise<void> {
 	const args = process.argv.slice(2)
+
+	// Handle global version flags
+	if (args.includes('--version') || args.includes('-v')) {
+		showVersion()
+		return
+	}
 
 	// Handle global help flags when no command is provided or help is explicitly requested
 	if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {


### PR DESCRIPTION
Introduce a new command to show the CLI version, enhancing user experience by providing version details directly from the command line. Update help text to include the new command and its usage.