### PR TITLE
Automate PR target branch change to develop

### DIFF
--- a/.github/workflows/pr-target-develop.yml
+++ b/.github/workflows/pr-target-develop.yml
@@ -40,7 +40,7 @@ jobs:
               await github.rest.pulls.update({
                 owner,
                 repo,
-                pull_request_number: prNumber,
+                pull_number: prNumber,
                 base: 'develop'
               });
               


### PR DESCRIPTION
Introduce a workflow that automatically changes the target branch of new pull requests from 'main' to 'develop', promoting a cleaner development process. The workflow also adds a comment to inform users of the change.

closes #58