### PR TITLE
[Redo] Add ASCII art logo and enhance output formatting

### DIFF
--- a/.github/workflows/pr-target-develop.yml
+++ b/.github/workflows/pr-target-develop.yml
@@ -52,9 +52,7 @@ jobs:
                 '',
                 'We use `develop` for all feature work. No action needed!',
                 '',
-                'If you need to target `main` (e.g. for a hotfix), close this PR and open a new one to `main` with `[HOTFIX]` in the title.',
-                '',
-                '*[PR Target Workflow]*'
+                'If you need to target `main` (e.g. for a hotfix), close this PR and open a new one to `main` with `[HOTFIX]` in the title.'
               ].join('\n');
               
               await github.rest.issues.createComment({

--- a/.github/workflows/pr-target-develop.yml
+++ b/.github/workflows/pr-target-develop.yml
@@ -48,6 +48,8 @@ jobs:
               
               // Add a comment explaining the change
               const commentBody = [
+                'Thanks for contributing to fabr! 🚀',
+                '',
                 '🔄 This PR was automatically retargeted from `main` to `develop`.',
                 '',
                 'We use `develop` for all feature work. No action needed!',

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -14,7 +14,7 @@ type HelpArgs = SubcommandArgs
  * @returns {void}
  */
 export function showGlobalHelp(): void {
-	console.log(chalk.redBright.bold( asciiArt() ))
+	console.log(chalk.redBright.bold(asciiArt()))
 	console.log(chalk.white('Usage:'))
 	console.log(chalk.cyan('  npx fabr <command>') + chalk.gray('  Execute a command\n'))
 	console.log(chalk.white('Available Commands:'))

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk'
 import { parseSubcommandArgs, parseSubcommandOnlyArgs } from '../lib/args.js'
 import { HelpContent } from '../lib/help.js'
 import { BaseSubcommand, SubcommandArgs } from '../types/subcommand.js'
+import { asciiArt } from '../lib/ascii.js'
 
 type HelpArgs = SubcommandArgs
 
@@ -13,7 +14,7 @@ type HelpArgs = SubcommandArgs
  * @returns {void}
  */
 export function showGlobalHelp(): void {
-	console.log(chalk.cyan.bold('Fabr - Project Template Generator 🚀\n'))
+	console.log(chalk.redBright.bold( asciiArt() ))
 	console.log(chalk.white('Usage:'))
 	console.log(chalk.cyan('  npx fabr <command>') + chalk.gray('  Execute a command\n'))
 	console.log(chalk.white('Available Commands:'))

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -142,7 +142,7 @@ export class InitCommand extends BaseSubcommand<InitArgs> {
 			}
 
 			// Display fabr ASCII logo
-			console.log(chalk.redBright(asciiArt()))
+			console.log(chalk.redBright.bold(asciiArt()))
 
 			// Get project details from user (skip prompts if already provided)
 			const { template, projectName: finalProjectName } = await promptForProjectDetails(

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -18,6 +18,7 @@ import { HelpContent } from '../lib/help.js'
 import { FabrConfig, isCommandBasedTemplate, validateFabrConfig } from '../types/fabr-config.js'
 import { BaseSubcommand, SubcommandArgs } from '../types/subcommand.js'
 import { Template, findTemplateBySlug } from '../types/templates.js'
+import { asciiArt } from '../lib/ascii.js'
 
 export interface InitArgs extends SubcommandArgs {
 	projectName?: string
@@ -140,7 +141,8 @@ export class InitCommand extends BaseSubcommand<InitArgs> {
 				}
 			}
 
-			console.log(chalk.cyan.bold('Welcome to Fabr! 🚀'))
+			// Display fabr ASCII logo
+			console.log(chalk.redBright(asciiArt()))
 
 			// Get project details from user (skip prompts if already provided)
 			const { template, projectName: finalProjectName } = await promptForProjectDetails(

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -36,7 +36,7 @@ function getVersion(): string {
  */
 export function showVersion(): void {
 	const version = getVersion()
-	console.log(chalk.cyan.bold(`Fabr v${version}`))
+	console.log(chalk.redBright.bold(`fabr v${version}`))
 }
 
 /**

--- a/src/lib/ascii.ts
+++ b/src/lib/ascii.ts
@@ -1,6 +1,6 @@
 /**
  * Returns the ASCII art string used in the CLI for the Fabr logo.
- * 
+ *
  * @returns The ASCII art string
  */
 export function asciiArt(): string {

--- a/src/lib/ascii.ts
+++ b/src/lib/ascii.ts
@@ -1,0 +1,15 @@
+/**
+ * Returns the ASCII art string used in the CLI for the Fabr logo.
+ * 
+ * @returns The ASCII art string
+ */
+export function asciiArt(): string {
+	return `
+    ____      __        
+   / __/___ _/ /_  _____
+  / /_/ __ \`/ __ \\/ ___/
+ / __/ /_/ / /_/ / /    
+/_/  \\__,_/_.___/_/     
+                                                
+	`
+}


### PR DESCRIPTION
Introduce an ASCII art function to display the Fabr logo in the welcome message and help command output. Update the version display color for consistency.

closes https://github.com/yashjawale/fabr/issues/55

> Created again to squash merge into develop for better changelog