### PR TITLE
Docs: add get to know CLI section

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -66,6 +66,7 @@ export default defineConfig({
 						{ label: 'Introduction', slug: 'docs/getting-started/introduction' },
 						{ label: 'Installation', slug: 'docs/getting-started/installation' },
 						{ label: 'Quick Start', slug: 'docs/getting-started/quick-start' },
+						{ label: 'Get to know the CLI', slug: 'docs/getting-started/cli-reference' },
 					],
 				},
 				{

--- a/website/src/content/docs/docs/api/commands/functions/executeCommand.md
+++ b/website/src/content/docs/docs/api/commands/functions/executeCommand.md
@@ -7,7 +7,7 @@ title: "executeCommand"
 
 > **executeCommand**(`commandName`, `templates`, `args`): `Promise`\<`void`\>
 
-Defined in: [commands/index.ts:65](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/index.ts#L65)
+Defined in: [commands/index.ts:65](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/index.ts#L65)
 
 Execute a command by name with the provided arguments.
 Looks up the command in the registry and delegates execution to the appropriate handler.

--- a/website/src/content/docs/docs/api/commands/functions/getAvailableCommands.md
+++ b/website/src/content/docs/docs/api/commands/functions/getAvailableCommands.md
@@ -7,7 +7,7 @@ title: "getAvailableCommands"
 
 > **getAvailableCommands**(): [`CommandDefinition`](/fabr/docs/api/commands/interfaces/commanddefinition/)[]
 
-Defined in: [commands/index.ts:88](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/index.ts#L88)
+Defined in: [commands/index.ts:88](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/index.ts#L88)
 
 Get list of all available commands with their definitions.
 Returns an array of CommandDefinition objects containing name, description, and handler.

--- a/website/src/content/docs/docs/api/commands/help/classes/HelpCommand.md
+++ b/website/src/content/docs/docs/api/commands/help/classes/HelpCommand.md
@@ -5,7 +5,7 @@ prev: false
 title: "HelpCommand"
 ---
 
-Defined in: [commands/help.ts:52](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/help.ts#L52)
+Defined in: [commands/help.ts:52](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/help.ts#L52)
 
 Show help information for the CLI
 
@@ -33,7 +33,7 @@ Show help information for the CLI
 
 > **execute**(): `Promise`\<`void`\>
 
-Defined in: [commands/help.ts:104](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/help.ts#L104)
+Defined in: [commands/help.ts:104](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/help.ts#L104)
 
 Execute the command with parsed arguments.
 Must be implemented by subclass to provide the command's functionality.
@@ -54,7 +54,7 @@ Promise that resolves when command execution is complete
 
 > **handle**(`templates`, `rawArgs`): `Promise`\<`void`\>
 
-Defined in: [types/subcommand.ts:94](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/subcommand.ts#L94)
+Defined in: [types/subcommand.ts:94](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/subcommand.ts#L94)
 
 Main handler that follows the common command pattern.
 Orchestrates the command execution workflow:
@@ -92,7 +92,7 @@ Promise that resolves when command handling is complete
 
 > **parseArgs**(`rawArgs`): [`SubcommandArgs`](/fabr/docs/api/types/subcommand/interfaces/subcommandargs/)
 
-Defined in: [commands/help.ts:80](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/help.ts#L80)
+Defined in: [commands/help.ts:80](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/help.ts#L80)
 
 Parse command line arguments for the help command.
 Extracts and validates arguments specific to the help command.
@@ -121,7 +121,7 @@ Parsed help command arguments
 
 > **showHelp**(): `void`
 
-Defined in: [commands/help.ts:95](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/help.ts#L95)
+Defined in: [commands/help.ts:95](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/help.ts#L95)
 
 Shows the help information specific to the help command.
 For the help command, this shows the global help.
@@ -140,7 +140,7 @@ For the help command, this shows the global help.
 
 > `readonly` **description**: `"Show this help message"` = `'Show this help message'`
 
-Defined in: [commands/help.ts:54](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/help.ts#L54)
+Defined in: [commands/help.ts:54](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/help.ts#L54)
 
 Command description - must be implemented by subclass.
 A brief description of what the command does, used in help text.
@@ -155,7 +155,7 @@ A brief description of what the command does, used in help text.
 
 > `readonly` **name**: `"help"` = `'help'`
 
-Defined in: [commands/help.ts:53](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/help.ts#L53)
+Defined in: [commands/help.ts:53](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/help.ts#L53)
 
 Command name - must be implemented by subclass.
 This should be the string used to invoke the command from the CLI.

--- a/website/src/content/docs/docs/api/commands/help/functions/showGlobalHelp.md
+++ b/website/src/content/docs/docs/api/commands/help/functions/showGlobalHelp.md
@@ -7,7 +7,7 @@ title: "showGlobalHelp"
 
 > **showGlobalHelp**(): `void`
 
-Defined in: [commands/help.ts:16](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/help.ts#L16)
+Defined in: [commands/help.ts:16](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/help.ts#L16)
 
 Show global help information for the Fabr CLI.
 Displays usage instructions, available commands, global options, and examples.

--- a/website/src/content/docs/docs/api/commands/init/classes/InitCommand.md
+++ b/website/src/content/docs/docs/api/commands/init/classes/InitCommand.md
@@ -5,7 +5,7 @@ prev: false
 title: "InitCommand"
 ---
 
-Defined in: [commands/init.ts:31](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/init.ts#L31)
+Defined in: [commands/init.ts:31](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/init.ts#L31)
 
 Create a new project from a template
 
@@ -33,7 +33,7 @@ Create a new project from a template
 
 > **execute**(`templates`, `args`): `Promise`\<`void`\>
 
-Defined in: [commands/init.ts:114](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/init.ts#L114)
+Defined in: [commands/init.ts:114](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/init.ts#L114)
 
 Execute the init command to create a new project from a template.
 
@@ -77,7 +77,7 @@ A promise that resolves when project creation is complete
 
 > **handle**(`templates`, `rawArgs`): `Promise`\<`void`\>
 
-Defined in: [types/subcommand.ts:94](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/subcommand.ts#L94)
+Defined in: [types/subcommand.ts:94](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/subcommand.ts#L94)
 
 Main handler that follows the common command pattern.
 Orchestrates the command execution workflow:
@@ -115,7 +115,7 @@ Promise that resolves when command handling is complete
 
 > **parseArgs**(`rawArgs`): [`InitArgs`](/fabr/docs/api/commands/init/interfaces/initargs/)
 
-Defined in: [commands/init.ts:80](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/init.ts#L80)
+Defined in: [commands/init.ts:80](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/init.ts#L80)
 
 Parse command line arguments for the init command.
 Extracts project name, template slug, and help flag from the provided arguments.
@@ -144,7 +144,7 @@ Parsed init command arguments including project name and template slug
 
 > **showHelp**(): `void`
 
-Defined in: [types/subcommand.ts:77](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/subcommand.ts#L77)
+Defined in: [types/subcommand.ts:77](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/subcommand.ts#L77)
 
 Show help for this command using the help content configuration.
 Uses the getHelpContent() method to format and display help information.
@@ -163,7 +163,7 @@ Uses the getHelpContent() method to format and display help information.
 
 > `readonly` **description**: `"Create a new project from a template"` = `'Create a new project from a template'`
 
-Defined in: [commands/init.ts:33](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/init.ts#L33)
+Defined in: [commands/init.ts:33](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/init.ts#L33)
 
 Command description - must be implemented by subclass.
 A brief description of what the command does, used in help text.
@@ -178,7 +178,7 @@ A brief description of what the command does, used in help text.
 
 > `readonly` **name**: `"init"` = `'init'`
 
-Defined in: [commands/init.ts:32](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/init.ts#L32)
+Defined in: [commands/init.ts:32](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/init.ts#L32)
 
 Command name - must be implemented by subclass.
 This should be the string used to invoke the command from the CLI.

--- a/website/src/content/docs/docs/api/commands/init/interfaces/InitArgs.md
+++ b/website/src/content/docs/docs/api/commands/init/interfaces/InitArgs.md
@@ -5,7 +5,7 @@ prev: false
 title: "InitArgs"
 ---
 
-Defined in: [commands/init.ts:23](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/init.ts#L23)
+Defined in: [commands/init.ts:23](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/init.ts#L23)
 
 ## Extends
 
@@ -17,7 +17,7 @@ Defined in: [commands/init.ts:23](https://github.com/yashjawale/fabr/blob/f01b72
 
 > **help**: `boolean`
 
-Defined in: [types/subcommand.ts:9](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/subcommand.ts#L9)
+Defined in: [types/subcommand.ts:9](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/subcommand.ts#L9)
 
 #### Inherited from
 
@@ -29,7 +29,7 @@ Defined in: [types/subcommand.ts:9](https://github.com/yashjawale/fabr/blob/f01b
 
 > `optional` **projectName**: `string`
 
-Defined in: [commands/init.ts:24](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/init.ts#L24)
+Defined in: [commands/init.ts:24](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/init.ts#L24)
 
 ***
 
@@ -37,4 +37,4 @@ Defined in: [commands/init.ts:24](https://github.com/yashjawale/fabr/blob/f01b72
 
 > `optional` **templateSlug**: `string`
 
-Defined in: [commands/init.ts:25](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/init.ts#L25)
+Defined in: [commands/init.ts:25](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/init.ts#L25)

--- a/website/src/content/docs/docs/api/commands/interfaces/CommandDefinition.md
+++ b/website/src/content/docs/docs/api/commands/interfaces/CommandDefinition.md
@@ -5,7 +5,7 @@ prev: false
 title: "CommandDefinition"
 ---
 
-Defined in: [commands/index.ts:10](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/index.ts#L10)
+Defined in: [commands/index.ts:10](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/index.ts#L10)
 
 ## Properties
 
@@ -13,7 +13,7 @@ Defined in: [commands/index.ts:10](https://github.com/yashjawale/fabr/blob/f01b7
 
 > **description**: `string`
 
-Defined in: [commands/index.ts:12](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/index.ts#L12)
+Defined in: [commands/index.ts:12](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/index.ts#L12)
 
 ***
 
@@ -21,7 +21,7 @@ Defined in: [commands/index.ts:12](https://github.com/yashjawale/fabr/blob/f01b7
 
 > **handler**: [`BaseSubcommand`](/fabr/docs/api/types/subcommand/classes/basesubcommand/)
 
-Defined in: [commands/index.ts:13](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/index.ts#L13)
+Defined in: [commands/index.ts:13](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/index.ts#L13)
 
 ***
 
@@ -29,4 +29,4 @@ Defined in: [commands/index.ts:13](https://github.com/yashjawale/fabr/blob/f01b7
 
 > **name**: `string`
 
-Defined in: [commands/index.ts:11](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/index.ts#L11)
+Defined in: [commands/index.ts:11](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/index.ts#L11)

--- a/website/src/content/docs/docs/api/commands/list/classes/ListCommand.md
+++ b/website/src/content/docs/docs/api/commands/list/classes/ListCommand.md
@@ -5,7 +5,7 @@ prev: false
 title: "ListCommand"
 ---
 
-Defined in: [commands/list.ts:12](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/list.ts#L12)
+Defined in: [commands/list.ts:12](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/list.ts#L12)
 
 List all available templates with their details
 
@@ -33,7 +33,7 @@ List all available templates with their details
 
 > **execute**(`templates`): `Promise`\<`void`\>
 
-Defined in: [commands/list.ts:61](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/list.ts#L61)
+Defined in: [commands/list.ts:61](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/list.ts#L61)
 
 Execute the list command.
 Displays all available templates with their names, slugs, and repositories.
@@ -63,7 +63,7 @@ A promise that resolves when the template list is displayed
 
 > **handle**(`templates`, `rawArgs`): `Promise`\<`void`\>
 
-Defined in: [types/subcommand.ts:94](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/subcommand.ts#L94)
+Defined in: [types/subcommand.ts:94](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/subcommand.ts#L94)
 
 Main handler that follows the common command pattern.
 Orchestrates the command execution workflow:
@@ -101,7 +101,7 @@ Promise that resolves when command handling is complete
 
 > **parseArgs**(`rawArgs`): [`SubcommandArgs`](/fabr/docs/api/types/subcommand/interfaces/subcommandargs/)
 
-Defined in: [commands/list.ts:43](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/list.ts#L43)
+Defined in: [commands/list.ts:43](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/list.ts#L43)
 
 Parse command line arguments for the list command.
 Extracts and validates arguments specific to the list command.
@@ -130,7 +130,7 @@ Parsed list command arguments
 
 > **showHelp**(): `void`
 
-Defined in: [types/subcommand.ts:77](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/subcommand.ts#L77)
+Defined in: [types/subcommand.ts:77](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/subcommand.ts#L77)
 
 Show help for this command using the help content configuration.
 Uses the getHelpContent() method to format and display help information.
@@ -149,7 +149,7 @@ Uses the getHelpContent() method to format and display help information.
 
 > `readonly` **description**: `"List all available templates"` = `'List all available templates'`
 
-Defined in: [commands/list.ts:14](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/list.ts#L14)
+Defined in: [commands/list.ts:14](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/list.ts#L14)
 
 Command description - must be implemented by subclass.
 A brief description of what the command does, used in help text.
@@ -164,7 +164,7 @@ A brief description of what the command does, used in help text.
 
 > `readonly` **name**: `"list"` = `'list'`
 
-Defined in: [commands/list.ts:13](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/list.ts#L13)
+Defined in: [commands/list.ts:13](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/list.ts#L13)
 
 Command name - must be implemented by subclass.
 This should be the string used to invoke the command from the CLI.

--- a/website/src/content/docs/docs/api/commands/search/classes/SearchCommand.md
+++ b/website/src/content/docs/docs/api/commands/search/classes/SearchCommand.md
@@ -5,7 +5,7 @@ prev: false
 title: "SearchCommand"
 ---
 
-Defined in: [commands/search.ts:16](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/search.ts#L16)
+Defined in: [commands/search.ts:16](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/search.ts#L16)
 
 Search through available templates and display matching results
 
@@ -33,7 +33,7 @@ Search through available templates and display matching results
 
 > **execute**(`templates`, `args`): `Promise`\<`void`\>
 
-Defined in: [commands/search.ts:154](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/search.ts#L154)
+Defined in: [commands/search.ts:154](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/search.ts#L154)
 
 Execute the search command.
 Performs the search based on provided query and options, then displays results.
@@ -69,7 +69,7 @@ A promise that resolves when the search is complete
 
 > **handle**(`templates`, `rawArgs`): `Promise`\<`void`\>
 
-Defined in: [types/subcommand.ts:94](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/subcommand.ts#L94)
+Defined in: [types/subcommand.ts:94](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/subcommand.ts#L94)
 
 Main handler that follows the common command pattern.
 Orchestrates the command execution workflow:
@@ -107,7 +107,7 @@ Promise that resolves when command handling is complete
 
 > **parseArgs**(`rawArgs`): `SearchArgs`
 
-Defined in: [commands/search.ts:62](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/search.ts#L62)
+Defined in: [commands/search.ts:62](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/search.ts#L62)
 
 Parse command line arguments for the search command.
 Extracts and validates arguments specific to the search command.
@@ -136,7 +136,7 @@ Parsed search command arguments
 
 > **showHelp**(): `void`
 
-Defined in: [types/subcommand.ts:77](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/subcommand.ts#L77)
+Defined in: [types/subcommand.ts:77](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/subcommand.ts#L77)
 
 Show help for this command using the help content configuration.
 Uses the getHelpContent() method to format and display help information.
@@ -155,7 +155,7 @@ Uses the getHelpContent() method to format and display help information.
 
 > `readonly` **description**: `"Search templates by name, slug, or repository"` = `'Search templates by name, slug, or repository'`
 
-Defined in: [commands/search.ts:18](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/search.ts#L18)
+Defined in: [commands/search.ts:18](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/search.ts#L18)
 
 Command description - must be implemented by subclass.
 A brief description of what the command does, used in help text.
@@ -170,7 +170,7 @@ A brief description of what the command does, used in help text.
 
 > `readonly` **name**: `"search"` = `'search'`
 
-Defined in: [commands/search.ts:17](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/search.ts#L17)
+Defined in: [commands/search.ts:17](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/search.ts#L17)
 
 Command name - must be implemented by subclass.
 This should be the string used to invoke the command from the CLI.

--- a/website/src/content/docs/docs/api/commands/variables/commands.md
+++ b/website/src/content/docs/docs/api/commands/variables/commands.md
@@ -7,6 +7,6 @@ title: "commands"
 
 > `const` **commands**: `Record`\<`string`, [`CommandDefinition`](/fabr/docs/api/commands/interfaces/commanddefinition/)\>
 
-Defined in: [commands/index.ts:26](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/index.ts#L26)
+Defined in: [commands/index.ts:26](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/index.ts#L26)
 
 Registry of all available commands

--- a/website/src/content/docs/docs/api/commands/version/classes/VersionCommand.md
+++ b/website/src/content/docs/docs/api/commands/version/classes/VersionCommand.md
@@ -5,7 +5,7 @@ prev: false
 title: "VersionCommand"
 ---
 
-Defined in: [commands/version.ts:45](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/version.ts#L45)
+Defined in: [commands/version.ts:45](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/version.ts#L45)
 
 Show version information for the CLI
 
@@ -33,7 +33,7 @@ Show version information for the CLI
 
 > **execute**(): `Promise`\<`void`\>
 
-Defined in: [commands/version.ts:88](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/version.ts#L88)
+Defined in: [commands/version.ts:88](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/version.ts#L88)
 
 Execute the version command.
 Displays version information and exits the process.
@@ -54,7 +54,7 @@ A promise that resolves when version is displayed
 
 > **handle**(`templates`, `rawArgs`): `Promise`\<`void`\>
 
-Defined in: [types/subcommand.ts:94](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/subcommand.ts#L94)
+Defined in: [types/subcommand.ts:94](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/subcommand.ts#L94)
 
 Main handler that follows the common command pattern.
 Orchestrates the command execution workflow:
@@ -92,7 +92,7 @@ Promise that resolves when command handling is complete
 
 > **parseArgs**(`rawArgs`): [`SubcommandArgs`](/fabr/docs/api/types/subcommand/interfaces/subcommandargs/)
 
-Defined in: [commands/version.ts:73](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/version.ts#L73)
+Defined in: [commands/version.ts:73](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/version.ts#L73)
 
 Parse command line arguments for the version command.
 Extracts and validates arguments specific to the version command.
@@ -121,7 +121,7 @@ Parsed version command arguments
 
 > **showHelp**(): `void`
 
-Defined in: [types/subcommand.ts:77](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/subcommand.ts#L77)
+Defined in: [types/subcommand.ts:77](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/subcommand.ts#L77)
 
 Show help for this command using the help content configuration.
 Uses the getHelpContent() method to format and display help information.
@@ -140,7 +140,7 @@ Uses the getHelpContent() method to format and display help information.
 
 > `readonly` **description**: `"Show version information"` = `'Show version information'`
 
-Defined in: [commands/version.ts:47](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/version.ts#L47)
+Defined in: [commands/version.ts:47](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/version.ts#L47)
 
 Command description - must be implemented by subclass.
 A brief description of what the command does, used in help text.
@@ -155,7 +155,7 @@ A brief description of what the command does, used in help text.
 
 > `readonly` **name**: `"version"` = `'version'`
 
-Defined in: [commands/version.ts:46](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/version.ts#L46)
+Defined in: [commands/version.ts:46](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/version.ts#L46)
 
 Command name - must be implemented by subclass.
 This should be the string used to invoke the command from the CLI.

--- a/website/src/content/docs/docs/api/commands/version/functions/showVersion.md
+++ b/website/src/content/docs/docs/api/commands/version/functions/showVersion.md
@@ -7,7 +7,7 @@ title: "showVersion"
 
 > **showVersion**(): `void`
 
-Defined in: [commands/version.ts:37](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/commands/version.ts#L37)
+Defined in: [commands/version.ts:37](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/commands/version.ts#L37)
 
 Show version information for the Fabr CLI.
 Displays the current version number.

--- a/website/src/content/docs/docs/api/lib/args/functions/parseArgs.md
+++ b/website/src/content/docs/docs/api/lib/args/functions/parseArgs.md
@@ -7,7 +7,7 @@ title: "parseArgs"
 
 > **parseArgs**(`args`): [`ParsedArgs`](/fabr/docs/api/lib/args/interfaces/parsedargs/)
 
-Defined in: [lib/args.ts:27](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/args.ts#L27)
+Defined in: [lib/args.ts:27](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/args.ts#L27)
 
 Parse command line arguments into a structured format.
 Handles positional arguments, flags (both long and short), and help flags.

--- a/website/src/content/docs/docs/api/lib/args/functions/parseSubcommandArgs.md
+++ b/website/src/content/docs/docs/api/lib/args/functions/parseSubcommandArgs.md
@@ -7,7 +7,7 @@ title: "parseSubcommandArgs"
 
 > **parseSubcommandArgs**(`args`, `commandName`): `string`[]
 
-Defined in: [lib/args.ts:154](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/args.ts#L154)
+Defined in: [lib/args.ts:154](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/args.ts#L154)
 
 Generic subcommand argument parser that removes the command name from arguments.
 If the first argument matches the command name, it removes it and returns the rest.

--- a/website/src/content/docs/docs/api/lib/args/functions/parseSubcommandOnlyArgs.md
+++ b/website/src/content/docs/docs/api/lib/args/functions/parseSubcommandOnlyArgs.md
@@ -7,7 +7,7 @@ title: "parseSubcommandOnlyArgs"
 
 > **parseSubcommandOnlyArgs**(`args`): `Omit`\<[`ParsedArgs`](/fabr/docs/api/lib/args/interfaces/parsedargs/), `"command"`\> & `object`
 
-Defined in: [lib/args.ts:91](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/args.ts#L91)
+Defined in: [lib/args.ts:91](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/args.ts#L91)
 
 Parse arguments for subcommands, treating all non-flag arguments as positional.
 Similar to parseArgs but doesn't distinguish between command and positional arguments.

--- a/website/src/content/docs/docs/api/lib/args/functions/slugifyProjectName.md
+++ b/website/src/content/docs/docs/api/lib/args/functions/slugifyProjectName.md
@@ -7,7 +7,7 @@ title: "slugifyProjectName"
 
 > **slugifyProjectName**(`name`): `string`
 
-Defined in: [lib/args.ts:176](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/args.ts#L176)
+Defined in: [lib/args.ts:176](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/args.ts#L176)
 
 Convert a string to a valid project name slug.
 Applies multiple transformations to ensure the name is suitable for directory/project names:

--- a/website/src/content/docs/docs/api/lib/args/functions/validateProjectName.md
+++ b/website/src/content/docs/docs/api/lib/args/functions/validateProjectName.md
@@ -7,7 +7,7 @@ title: "validateProjectName"
 
 > **validateProjectName**(`name`): `object`
 
-Defined in: [lib/args.ts:205](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/args.ts#L205)
+Defined in: [lib/args.ts:205](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/args.ts#L205)
 
 Validate project name format and provide suggestions if invalid.
 Checks for empty names, invalid characters, and length limits.

--- a/website/src/content/docs/docs/api/lib/args/interfaces/ParsedArgs.md
+++ b/website/src/content/docs/docs/api/lib/args/interfaces/ParsedArgs.md
@@ -5,7 +5,7 @@ prev: false
 title: "ParsedArgs"
 ---
 
-Defined in: [lib/args.ts:5](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/args.ts#L5)
+Defined in: [lib/args.ts:5](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/args.ts#L5)
 
 Argument parsing utilities for the Fabr CLI
 
@@ -15,7 +15,7 @@ Argument parsing utilities for the Fabr CLI
 
 > `optional` **command**: `string`
 
-Defined in: [lib/args.ts:6](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/args.ts#L6)
+Defined in: [lib/args.ts:6](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/args.ts#L6)
 
 ***
 
@@ -23,7 +23,7 @@ Defined in: [lib/args.ts:6](https://github.com/yashjawale/fabr/blob/f01b72cf7871
 
 > **flags**: `Record`\<`string`, `string` \| `boolean`\>
 
-Defined in: [lib/args.ts:8](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/args.ts#L8)
+Defined in: [lib/args.ts:8](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/args.ts#L8)
 
 ***
 
@@ -31,7 +31,7 @@ Defined in: [lib/args.ts:8](https://github.com/yashjawale/fabr/blob/f01b72cf7871
 
 > **help**: `boolean`
 
-Defined in: [lib/args.ts:9](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/args.ts#L9)
+Defined in: [lib/args.ts:9](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/args.ts#L9)
 
 ***
 
@@ -39,4 +39,4 @@ Defined in: [lib/args.ts:9](https://github.com/yashjawale/fabr/blob/f01b72cf7871
 
 > **positional**: `string`[]
 
-Defined in: [lib/args.ts:7](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/args.ts#L7)
+Defined in: [lib/args.ts:7](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/args.ts#L7)

--- a/website/src/content/docs/docs/api/lib/args/interfaces/SubcommandResult.md
+++ b/website/src/content/docs/docs/api/lib/args/interfaces/SubcommandResult.md
@@ -5,7 +5,7 @@ prev: false
 title: "SubcommandResult"
 ---
 
-Defined in: [lib/args.ts:12](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/args.ts#L12)
+Defined in: [lib/args.ts:12](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/args.ts#L12)
 
 ## Type Parameters
 
@@ -19,7 +19,7 @@ Defined in: [lib/args.ts:12](https://github.com/yashjawale/fabr/blob/f01b72cf787
 
 > **args**: `T`
 
-Defined in: [lib/args.ts:13](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/args.ts#L13)
+Defined in: [lib/args.ts:13](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/args.ts#L13)
 
 ***
 
@@ -27,4 +27,4 @@ Defined in: [lib/args.ts:13](https://github.com/yashjawale/fabr/blob/f01b72cf787
 
 > **help**: `boolean`
 
-Defined in: [lib/args.ts:14](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/args.ts#L14)
+Defined in: [lib/args.ts:14](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/args.ts#L14)

--- a/website/src/content/docs/docs/api/lib/ascii/functions/asciiArt.md
+++ b/website/src/content/docs/docs/api/lib/ascii/functions/asciiArt.md
@@ -7,7 +7,7 @@ title: "asciiArt"
 
 > **asciiArt**(): `string`
 
-Defined in: [lib/ascii.ts:6](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/ascii.ts#L6)
+Defined in: [lib/ascii.ts:6](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/ascii.ts#L6)
 
 Returns the ASCII art string used in the CLI for the Fabr logo.
 

--- a/website/src/content/docs/docs/api/lib/commands/functions/executeCommandTemplates.md
+++ b/website/src/content/docs/docs/api/lib/commands/functions/executeCommandTemplates.md
@@ -7,7 +7,7 @@ title: "executeCommandTemplates"
 
 > **executeCommandTemplates**(`commands`, `placeholderValues`, `projectPath`): `Promise`\<`void`\>
 
-Defined in: [lib/commands.ts:41](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/commands.ts#L41)
+Defined in: [lib/commands.ts:41](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/commands.ts#L41)
 
 Execute a list of command templates with placeholder replacement.
 Processes each command template by replacing placeholders with their values,

--- a/website/src/content/docs/docs/api/lib/commands/functions/replacePlaceholdersInCommand.md
+++ b/website/src/content/docs/docs/api/lib/commands/functions/replacePlaceholdersInCommand.md
@@ -7,7 +7,7 @@ title: "replacePlaceholdersInCommand"
 
 > **replacePlaceholdersInCommand**(`command`, `placeholderValues`): `string`
 
-Defined in: [lib/commands.ts:110](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/commands.ts#L110)
+Defined in: [lib/commands.ts:110](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/commands.ts#L110)
 
 Replace placeholders in a command string with their corresponding values.
 Searches for placeholder patterns in the format {{PLACEHOLDER_NAME}} and replaces

--- a/website/src/content/docs/docs/api/lib/commands/functions/validateCommandPlaceholders.md
+++ b/website/src/content/docs/docs/api/lib/commands/functions/validateCommandPlaceholders.md
@@ -7,7 +7,7 @@ title: "validateCommandPlaceholders"
 
 > **validateCommandPlaceholders**(`commands`, `placeholderValues`): `string`[]
 
-Defined in: [lib/commands.ts:136](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/commands.ts#L136)
+Defined in: [lib/commands.ts:136](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/commands.ts#L136)
 
 Validate that all placeholders in commands have corresponding values.
 Scans all command templates for placeholder patterns and checks if each

--- a/website/src/content/docs/docs/api/lib/env/functions/createEnvironmentFiles.md
+++ b/website/src/content/docs/docs/api/lib/env/functions/createEnvironmentFiles.md
@@ -7,7 +7,7 @@ title: "createEnvironmentFiles"
 
 > **createEnvironmentFiles**(`projectPath`, `regularEnvVars`, `localEnvVars`): `void`
 
-Defined in: [lib/env.ts:162](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/env.ts#L162)
+Defined in: [lib/env.ts:162](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/env.ts#L162)
 
 Creates .env and .env.local files with the provided environment variables.
 Writes environment variables to appropriate files based on their categorization.

--- a/website/src/content/docs/docs/api/lib/env/functions/processAndCreateEnvironmentFiles.md
+++ b/website/src/content/docs/docs/api/lib/env/functions/processAndCreateEnvironmentFiles.md
@@ -7,7 +7,7 @@ title: "processAndCreateEnvironmentFiles"
 
 > **processAndCreateEnvironmentFiles**(`envVarConfig`, `placeholderValues`, `projectPath`): `Promise`\<`void`\>
 
-Defined in: [lib/env.ts:207](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/env.ts#L207)
+Defined in: [lib/env.ts:207](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/env.ts#L207)
 
 Processes environment variables and creates the appropriate .env files.
 Combines the processing of environment variable configurations with file creation.
@@ -19,7 +19,7 @@ This is a convenience function that handles the complete environment variable wo
 
 The array of environment variable configurations
 
-`undefined` | [`EnvironmentVariable`](/fabr/docs/api/types/fabr-config/interfaces/environmentvariable/)[]
+[`EnvironmentVariable`](/fabr/docs/api/types/fabr-config/interfaces/environmentvariable/)[] | `undefined`
 
 ### placeholderValues
 

--- a/website/src/content/docs/docs/api/lib/env/functions/processEnvironmentVariables.md
+++ b/website/src/content/docs/docs/api/lib/env/functions/processEnvironmentVariables.md
@@ -7,7 +7,7 @@ title: "processEnvironmentVariables"
 
 > **processEnvironmentVariables**(`envVarConfig`, `placeholderValues`): `Promise`\<\{ `local`: `Record`\<`string`, `string`\>; `regular`: `Record`\<`string`, `string`\>; \}\>
 
-Defined in: [lib/env.ts:55](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/env.ts#L55)
+Defined in: [lib/env.ts:55](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/env.ts#L55)
 
 Processes environment variable configurations to get final values.
 Handles both prompted environment variables (requiring user input) and transformed
@@ -20,7 +20,7 @@ regular (.env) and local (.env.local) categories based on their configuration.
 
 The array of environment variable configuration objects
 
-`undefined` | [`EnvironmentVariable`](/fabr/docs/api/types/fabr-config/interfaces/environmentvariable/)[]
+[`EnvironmentVariable`](/fabr/docs/api/types/fabr-config/interfaces/environmentvariable/)[] | `undefined`
 
 ### placeholderValues
 

--- a/website/src/content/docs/docs/api/lib/files/functions/findAndReplace.md
+++ b/website/src/content/docs/docs/api/lib/files/functions/findAndReplace.md
@@ -7,7 +7,7 @@ title: "findAndReplace"
 
 > **findAndReplace**(`projectPath`, `placeholderValues`): `void`
 
-Defined in: [lib/files.ts:40](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/files.ts#L40)
+Defined in: [lib/files.ts:40](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/files.ts#L40)
 
 Finds and replaces placeholder values in all files within a directory.
 Recursively processes all files in the project directory, searching for placeholder

--- a/website/src/content/docs/docs/api/lib/help/functions/formatHelpContent.md
+++ b/website/src/content/docs/docs/api/lib/help/functions/formatHelpContent.md
@@ -7,7 +7,7 @@ title: "formatHelpContent"
 
 > **formatHelpContent**(`commandName`, `content`): `string`
 
-Defined in: [lib/help.ts:24](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/help.ts#L24)
+Defined in: [lib/help.ts:24](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/help.ts#L24)
 
 Format help content into a readable string.
 Takes help content configuration and formats it into a structured help message

--- a/website/src/content/docs/docs/api/lib/help/interfaces/HelpContent.md
+++ b/website/src/content/docs/docs/api/lib/help/interfaces/HelpContent.md
@@ -5,7 +5,7 @@ prev: false
 title: "HelpContent"
 ---
 
-Defined in: [lib/help.ts:5](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/help.ts#L5)
+Defined in: [lib/help.ts:5](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/help.ts#L5)
 
 Utilities for help content formatting
 
@@ -15,7 +15,7 @@ Utilities for help content formatting
 
 > `optional` **arguments**: `object`[]
 
-Defined in: [lib/help.ts:8](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/help.ts#L8)
+Defined in: [lib/help.ts:8](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/help.ts#L8)
 
 #### description
 
@@ -31,7 +31,7 @@ Defined in: [lib/help.ts:8](https://github.com/yashjawale/fabr/blob/f01b72cf7871
 
 > `optional` **description**: `string`
 
-Defined in: [lib/help.ts:7](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/help.ts#L7)
+Defined in: [lib/help.ts:7](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/help.ts#L7)
 
 ***
 
@@ -39,7 +39,7 @@ Defined in: [lib/help.ts:7](https://github.com/yashjawale/fabr/blob/f01b72cf7871
 
 > `optional` **examples**: `object`[]
 
-Defined in: [lib/help.ts:10](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/help.ts#L10)
+Defined in: [lib/help.ts:10](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/help.ts#L10)
 
 #### command
 
@@ -55,7 +55,7 @@ Defined in: [lib/help.ts:10](https://github.com/yashjawale/fabr/blob/f01b72cf787
 
 > `optional` **options**: `object`[]
 
-Defined in: [lib/help.ts:9](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/help.ts#L9)
+Defined in: [lib/help.ts:9](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/help.ts#L9)
 
 #### description
 
@@ -71,4 +71,4 @@ Defined in: [lib/help.ts:9](https://github.com/yashjawale/fabr/blob/f01b72cf7871
 
 > `optional` **usage**: `string`
 
-Defined in: [lib/help.ts:6](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/help.ts#L6)
+Defined in: [lib/help.ts:6](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/help.ts#L6)

--- a/website/src/content/docs/docs/api/lib/placeholders/functions/processPlaceholders.md
+++ b/website/src/content/docs/docs/api/lib/placeholders/functions/processPlaceholders.md
@@ -7,7 +7,7 @@ title: "processPlaceholders"
 
 > **processPlaceholders**(`placeholderConfig`): `Promise`\<`Record`\<`string`, `string`\>\>
 
-Defined in: [lib/placeholders.ts:47](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/placeholders.ts#L47)
+Defined in: [lib/placeholders.ts:47](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/placeholders.ts#L47)
 
 Processes placeholder configurations to get final values.
 Handles both prompted placeholders (requiring user input) and derived placeholders
@@ -20,7 +20,7 @@ then derives transformed placeholders from the collected values.
 
 The array of placeholder configuration objects
 
-`undefined` | [`Placeholder`](/fabr/docs/api/types/fabr-config/interfaces/placeholder/)[]
+[`Placeholder`](/fabr/docs/api/types/fabr-config/interfaces/placeholder/)[] | `undefined`
 
 ## Returns
 

--- a/website/src/content/docs/docs/api/lib/shell/functions/runShellCommand.md
+++ b/website/src/content/docs/docs/api/lib/shell/functions/runShellCommand.md
@@ -7,7 +7,7 @@ title: "runShellCommand"
 
 > **runShellCommand**(`command`, `spinnerText`): `Promise`\<`void`\>
 
-Defined in: [lib/shell.ts:17](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/shell.ts#L17)
+Defined in: [lib/shell.ts:17](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/shell.ts#L17)
 
 Executes a shell command with a spinner for user feedback.
 Supports chaining commands with && operator and provides visual feedback.
@@ -19,7 +19,7 @@ Shows a spinner during execution and success/error messages when complete.
 
 The shell command to execute (can include && for chaining). If undefined, the function returns immediately.
 
-`undefined` | `string`
+`string` | `undefined`
 
 ### spinnerText
 

--- a/website/src/content/docs/docs/api/lib/templates/functions/loadTemplates.md
+++ b/website/src/content/docs/docs/api/lib/templates/functions/loadTemplates.md
@@ -7,7 +7,7 @@ title: "loadTemplates"
 
 > **loadTemplates**(`options`): `Promise`\<[`TemplatesConfig`](/fabr/docs/api/types/templates/interfaces/templatesconfig/)\>
 
-Defined in: [lib/templates.ts:41](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/templates.ts#L41)
+Defined in: [lib/templates.ts:41](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/templates.ts#L41)
 
 Load templates configuration from GitHub repository.
 

--- a/website/src/content/docs/docs/api/lib/ui/functions/promptForProjectDetails.md
+++ b/website/src/content/docs/docs/api/lib/ui/functions/promptForProjectDetails.md
@@ -7,7 +7,7 @@ title: "promptForProjectDetails"
 
 > **promptForProjectDetails**(`templates`, `providedProjectName?`, `providedTemplate?`): `Promise`\<\{ `projectName`: `string`; `template`: `string`; \}\>
 
-Defined in: [lib/ui.ts:15](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/lib/ui.ts#L15)
+Defined in: [lib/ui.ts:15](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/lib/ui.ts#L15)
 
 Prompts the user for the initial project setup information.
 Handles interactive prompting for template selection and project name if not provided.

--- a/website/src/content/docs/docs/api/types/fabr-config/functions/isCommandBasedTemplate.md
+++ b/website/src/content/docs/docs/api/types/fabr-config/functions/isCommandBasedTemplate.md
@@ -7,7 +7,7 @@ title: "isCommandBasedTemplate"
 
 > **isCommandBasedTemplate**(`config`): `boolean`
 
-Defined in: [types/fabr-config.ts:178](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L178)
+Defined in: [types/fabr-config.ts:178](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L178)
 
 Type guard to check if a config is a command-based template.
 Command-based templates execute commands to generate files rather than using file copying.

--- a/website/src/content/docs/docs/api/types/fabr-config/functions/isFileBasedTemplate.md
+++ b/website/src/content/docs/docs/api/types/fabr-config/functions/isFileBasedTemplate.md
@@ -7,7 +7,7 @@ title: "isFileBasedTemplate"
 
 > **isFileBasedTemplate**(`config`): `boolean`
 
-Defined in: [types/fabr-config.ts:190](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L190)
+Defined in: [types/fabr-config.ts:190](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L190)
 
 Type guard to check if a config is a file-based template.
 File-based templates copy and modify files rather than executing commands to generate content.

--- a/website/src/content/docs/docs/api/types/fabr-config/functions/isPromptedEnvironmentVariable.md
+++ b/website/src/content/docs/docs/api/types/fabr-config/functions/isPromptedEnvironmentVariable.md
@@ -7,7 +7,7 @@ title: "isPromptedEnvironmentVariable"
 
 > **isPromptedEnvironmentVariable**(`envVar`): `boolean`
 
-Defined in: [types/fabr-config.ts:154](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L154)
+Defined in: [types/fabr-config.ts:154](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L154)
 
 Type guard to check if an environment variable is a prompted environment variable.
 A prompted environment variable requires user input and is not transformed from a placeholder.

--- a/website/src/content/docs/docs/api/types/fabr-config/functions/isPromptedPlaceholder.md
+++ b/website/src/content/docs/docs/api/types/fabr-config/functions/isPromptedPlaceholder.md
@@ -7,7 +7,7 @@ title: "isPromptedPlaceholder"
 
 > **isPromptedPlaceholder**(`placeholder`): `boolean`
 
-Defined in: [types/fabr-config.ts:130](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L130)
+Defined in: [types/fabr-config.ts:130](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L130)
 
 Type guard to check if a placeholder is a prompted placeholder.
 A prompted placeholder is one that requires user input and is not transformed from another placeholder.

--- a/website/src/content/docs/docs/api/types/fabr-config/functions/isTransformedEnvironmentVariable.md
+++ b/website/src/content/docs/docs/api/types/fabr-config/functions/isTransformedEnvironmentVariable.md
@@ -7,7 +7,7 @@ title: "isTransformedEnvironmentVariable"
 
 > **isTransformedEnvironmentVariable**(`envVar`): `boolean`
 
-Defined in: [types/fabr-config.ts:166](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L166)
+Defined in: [types/fabr-config.ts:166](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L166)
 
 Type guard to check if an environment variable is a transformed environment variable.
 A transformed environment variable derives its value from a placeholder using case transformation.

--- a/website/src/content/docs/docs/api/types/fabr-config/functions/isTransformedPlaceholder.md
+++ b/website/src/content/docs/docs/api/types/fabr-config/functions/isTransformedPlaceholder.md
@@ -7,7 +7,7 @@ title: "isTransformedPlaceholder"
 
 > **isTransformedPlaceholder**(`placeholder`): `boolean`
 
-Defined in: [types/fabr-config.ts:142](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L142)
+Defined in: [types/fabr-config.ts:142](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L142)
 
 Type guard to check if a placeholder is a transformed placeholder.
 A transformed placeholder derives its value from another placeholder using case transformation.

--- a/website/src/content/docs/docs/api/types/fabr-config/functions/validateFabrConfig.md
+++ b/website/src/content/docs/docs/api/types/fabr-config/functions/validateFabrConfig.md
@@ -7,7 +7,7 @@ title: "validateFabrConfig"
 
 > **validateFabrConfig**(`config`): `config is FabrConfig`
 
-Defined in: [types/fabr-config.ts:203](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L203)
+Defined in: [types/fabr-config.ts:203](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L203)
 
 Validates a fabr config object against the expected structure.
 Performs basic validation of the configuration object structure and placeholder definitions.

--- a/website/src/content/docs/docs/api/types/fabr-config/interfaces/CommandTemplate.md
+++ b/website/src/content/docs/docs/api/types/fabr-config/interfaces/CommandTemplate.md
@@ -5,7 +5,7 @@ prev: false
 title: "CommandTemplate"
 ---
 
-Defined in: [types/fabr-config.ts:80](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L80)
+Defined in: [types/fabr-config.ts:80](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L80)
 
 ## Properties
 
@@ -13,7 +13,7 @@ Defined in: [types/fabr-config.ts:80](https://github.com/yashjawale/fabr/blob/f0
 
 > **command**: `string`
 
-Defined in: [types/fabr-config.ts:82](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L82)
+Defined in: [types/fabr-config.ts:82](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L82)
 
 The command to execute
 
@@ -23,7 +23,7 @@ The command to execute
 
 > `optional` **description**: `string`
 
-Defined in: [types/fabr-config.ts:84](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L84)
+Defined in: [types/fabr-config.ts:84](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L84)
 
 Description of what this command does
 
@@ -33,7 +33,7 @@ Description of what this command does
 
 > `optional` **showOutput**: `boolean`
 
-Defined in: [types/fabr-config.ts:88](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L88)
+Defined in: [types/fabr-config.ts:88](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L88)
 
 Whether to show command output (default: true)
 
@@ -43,6 +43,6 @@ Whether to show command output (default: true)
 
 > `optional` **workingDirectory**: `string`
 
-Defined in: [types/fabr-config.ts:86](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L86)
+Defined in: [types/fabr-config.ts:86](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L86)
 
 Working directory for this command (relative to project root)

--- a/website/src/content/docs/docs/api/types/fabr-config/interfaces/EnvironmentVariable.md
+++ b/website/src/content/docs/docs/api/types/fabr-config/interfaces/EnvironmentVariable.md
@@ -5,7 +5,7 @@ prev: false
 title: "EnvironmentVariable"
 ---
 
-Defined in: [types/fabr-config.ts:52](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L52)
+Defined in: [types/fabr-config.ts:52](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L52)
 
 ## Properties
 
@@ -13,7 +13,7 @@ Defined in: [types/fabr-config.ts:52](https://github.com/yashjawale/fabr/blob/f0
 
 > `optional` **default**: `string`
 
-Defined in: [types/fabr-config.ts:60](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L60)
+Defined in: [types/fabr-config.ts:60](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L60)
 
 Default value for this environment variable
 
@@ -23,7 +23,7 @@ Default value for this environment variable
 
 > `optional` **defaultCase**: [`PlaceholderDefaultCase`](/fabr/docs/api/types/fabr-config/interfaces/placeholderdefaultcase/)
 
-Defined in: [types/fabr-config.ts:68](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L68)
+Defined in: [types/fabr-config.ts:68](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L68)
 
 Generate a default value by transforming a placeholder
 
@@ -33,7 +33,7 @@ Generate a default value by transforming a placeholder
 
 > `optional` **description**: `string`
 
-Defined in: [types/fabr-config.ts:58](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L58)
+Defined in: [types/fabr-config.ts:58](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L58)
 
 Additional description or help text for this environment variable
 
@@ -43,7 +43,7 @@ Additional description or help text for this environment variable
 
 > **key**: `string`
 
-Defined in: [types/fabr-config.ts:54](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L54)
+Defined in: [types/fabr-config.ts:54](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L54)
 
 The environment variable name (e.g., 'DATABASE_URL', 'API_KEY')
 
@@ -53,7 +53,7 @@ The environment variable name (e.g., 'DATABASE_URL', 'API_KEY')
 
 > `optional` **local**: `boolean`
 
-Defined in: [types/fabr-config.ts:64](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L64)
+Defined in: [types/fabr-config.ts:64](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L64)
 
 Whether this should be saved to .env.local instead of .env (for sensitive values)
 
@@ -63,7 +63,7 @@ Whether this should be saved to .env.local instead of .env (for sensitive values
 
 > `optional` **prompt**: `string`
 
-Defined in: [types/fabr-config.ts:56](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L56)
+Defined in: [types/fabr-config.ts:56](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L56)
 
 The message to show when prompting for this value
 
@@ -73,7 +73,7 @@ The message to show when prompting for this value
 
 > `optional` **required**: `boolean`
 
-Defined in: [types/fabr-config.ts:62](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L62)
+Defined in: [types/fabr-config.ts:62](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L62)
 
 Whether this environment variable is required
 
@@ -83,7 +83,7 @@ Whether this environment variable is required
 
 > `optional` **transform**: [`PlaceholderTransform`](/fabr/docs/api/types/fabr-config/interfaces/placeholdertransform/)
 
-Defined in: [types/fabr-config.ts:66](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L66)
+Defined in: [types/fabr-config.ts:66](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L66)
 
 Transform this environment variable's value from a placeholder
 
@@ -93,6 +93,6 @@ Transform this environment variable's value from a placeholder
 
 > `optional` **validate**: [`PlaceholderValidation`](/fabr/docs/api/types/fabr-config/interfaces/placeholdervalidation/)
 
-Defined in: [types/fabr-config.ts:70](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L70)
+Defined in: [types/fabr-config.ts:70](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L70)
 
 Validation rules for this environment variable

--- a/website/src/content/docs/docs/api/types/fabr-config/interfaces/FabrConfig.md
+++ b/website/src/content/docs/docs/api/types/fabr-config/interfaces/FabrConfig.md
@@ -5,7 +5,7 @@ prev: false
 title: "FabrConfig"
 ---
 
-Defined in: [types/fabr-config.ts:91](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L91)
+Defined in: [types/fabr-config.ts:91](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L91)
 
 ## Properties
 
@@ -13,7 +13,7 @@ Defined in: [types/fabr-config.ts:91](https://github.com/yashjawale/fabr/blob/f0
 
 > `optional` **commands**: [`CommandTemplate`](/fabr/docs/api/types/fabr-config/interfaces/commandtemplate/)[]
 
-Defined in: [types/fabr-config.ts:119](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L119)
+Defined in: [types/fabr-config.ts:119](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L119)
 
 Array of commands to run for command-based templates
 
@@ -23,7 +23,7 @@ Array of commands to run for command-based templates
 
 > `optional` **description**: `string`
 
-Defined in: [types/fabr-config.ts:95](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L95)
+Defined in: [types/fabr-config.ts:95](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L95)
 
 A brief description of what this template creates
 
@@ -33,7 +33,7 @@ A brief description of what this template creates
 
 > `optional` **environmentVariables**: [`EnvironmentVariable`](/fabr/docs/api/types/fabr-config/interfaces/environmentvariable/)[]
 
-Defined in: [types/fabr-config.ts:111](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L111)
+Defined in: [types/fabr-config.ts:111](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L111)
 
 Array of environment variable configurations
 
@@ -43,7 +43,7 @@ Array of environment variable configurations
 
 > `optional` **files**: [`FileConfiguration`](/fabr/docs/api/types/fabr-config/interfaces/fileconfiguration/)
 
-Defined in: [types/fabr-config.ts:113](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L113)
+Defined in: [types/fabr-config.ts:113](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L113)
 
 File-specific configurations
 
@@ -53,7 +53,7 @@ File-specific configurations
 
 > `optional` **gitInit**: `boolean`
 
-Defined in: [types/fabr-config.ts:115](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L115)
+Defined in: [types/fabr-config.ts:115](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L115)
 
 Whether to initialize a git repository after setup
 
@@ -63,7 +63,7 @@ Whether to initialize a git repository after setup
 
 > `optional` **installCommand**: `string`
 
-Defined in: [types/fabr-config.ts:105](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L105)
+Defined in: [types/fabr-config.ts:105](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L105)
 
 Command to install dependencies
 
@@ -73,7 +73,7 @@ Command to install dependencies
 
 > `optional` **name**: `string`
 
-Defined in: [types/fabr-config.ts:93](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L93)
+Defined in: [types/fabr-config.ts:93](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L93)
 
 The name of the template configuration
 
@@ -83,7 +83,7 @@ The name of the template configuration
 
 > `optional` **placeholders**: [`Placeholder`](/fabr/docs/api/types/fabr-config/interfaces/placeholder/)[]
 
-Defined in: [types/fabr-config.ts:109](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L109)
+Defined in: [types/fabr-config.ts:109](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L109)
 
 Array of placeholder configurations for template customization
 
@@ -93,7 +93,7 @@ Array of placeholder configurations for template customization
 
 > `optional` **postInstallCommand**: `string`
 
-Defined in: [types/fabr-config.ts:107](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L107)
+Defined in: [types/fabr-config.ts:107](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L107)
 
 Command to run after dependency installation
 
@@ -103,7 +103,7 @@ Command to run after dependency installation
 
 > `optional` **postSetupCommand**: `string`
 
-Defined in: [types/fabr-config.ts:103](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L103)
+Defined in: [types/fabr-config.ts:103](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L103)
 
 Command to run after placeholder replacement
 
@@ -113,7 +113,7 @@ Command to run after placeholder replacement
 
 > `optional` **preSetupCommand**: `string`
 
-Defined in: [types/fabr-config.ts:101](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L101)
+Defined in: [types/fabr-config.ts:101](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L101)
 
 Command to run before any setup tasks
 
@@ -123,7 +123,7 @@ Command to run before any setup tasks
 
 > `optional` **removeFiles**: `string`[]
 
-Defined in: [types/fabr-config.ts:117](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L117)
+Defined in: [types/fabr-config.ts:117](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L117)
 
 Array of file patterns to remove after setup completion
 
@@ -133,7 +133,7 @@ Array of file patterns to remove after setup completion
 
 > `optional` **type**: `"files"` \| `"commands"`
 
-Defined in: [types/fabr-config.ts:99](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L99)
+Defined in: [types/fabr-config.ts:99](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L99)
 
 Template type: 'files' (default) or 'commands'
 
@@ -143,6 +143,6 @@ Template type: 'files' (default) or 'commands'
 
 > `optional` **version**: `string`
 
-Defined in: [types/fabr-config.ts:97](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L97)
+Defined in: [types/fabr-config.ts:97](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L97)
 
 Version of the template configuration

--- a/website/src/content/docs/docs/api/types/fabr-config/interfaces/FileConfiguration.md
+++ b/website/src/content/docs/docs/api/types/fabr-config/interfaces/FileConfiguration.md
@@ -5,7 +5,7 @@ prev: false
 title: "FileConfiguration"
 ---
 
-Defined in: [types/fabr-config.ts:73](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L73)
+Defined in: [types/fabr-config.ts:73](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L73)
 
 ## Properties
 
@@ -13,7 +13,7 @@ Defined in: [types/fabr-config.ts:73](https://github.com/yashjawale/fabr/blob/f0
 
 > `optional` **ignore**: `string`[]
 
-Defined in: [types/fabr-config.ts:75](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L75)
+Defined in: [types/fabr-config.ts:75](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L75)
 
 Array of file patterns to ignore during placeholder replacement
 
@@ -23,6 +23,6 @@ Array of file patterns to ignore during placeholder replacement
 
 > `optional` **include**: `string`[]
 
-Defined in: [types/fabr-config.ts:77](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L77)
+Defined in: [types/fabr-config.ts:77](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L77)
 
 Array of file patterns to specifically include for placeholder replacement

--- a/website/src/content/docs/docs/api/types/fabr-config/interfaces/Placeholder.md
+++ b/website/src/content/docs/docs/api/types/fabr-config/interfaces/Placeholder.md
@@ -5,7 +5,7 @@ prev: false
 title: "Placeholder"
 ---
 
-Defined in: [types/fabr-config.ts:33](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L33)
+Defined in: [types/fabr-config.ts:33](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L33)
 
 ## Properties
 
@@ -13,7 +13,7 @@ Defined in: [types/fabr-config.ts:33](https://github.com/yashjawale/fabr/blob/f0
 
 > `optional` **default**: `string`
 
-Defined in: [types/fabr-config.ts:41](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L41)
+Defined in: [types/fabr-config.ts:41](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L41)
 
 Default value for this placeholder
 
@@ -23,7 +23,7 @@ Default value for this placeholder
 
 > `optional` **defaultCase**: [`PlaceholderDefaultCase`](/fabr/docs/api/types/fabr-config/interfaces/placeholderdefaultcase/)
 
-Defined in: [types/fabr-config.ts:47](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L47)
+Defined in: [types/fabr-config.ts:47](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L47)
 
 Generate a default value by transforming another placeholder
 
@@ -33,7 +33,7 @@ Generate a default value by transforming another placeholder
 
 > `optional` **description**: `string`
 
-Defined in: [types/fabr-config.ts:39](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L39)
+Defined in: [types/fabr-config.ts:39](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L39)
 
 Additional description or help text for this placeholder
 
@@ -43,7 +43,7 @@ Additional description or help text for this placeholder
 
 > **key**: `string`
 
-Defined in: [types/fabr-config.ts:35](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L35)
+Defined in: [types/fabr-config.ts:35](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L35)
 
 The placeholder key (e.g., 'PROJECT_NAME', 'AUTHOR_NAME')
 
@@ -53,7 +53,7 @@ The placeholder key (e.g., 'PROJECT_NAME', 'AUTHOR_NAME')
 
 > `optional` **prompt**: `string`
 
-Defined in: [types/fabr-config.ts:37](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L37)
+Defined in: [types/fabr-config.ts:37](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L37)
 
 The message to show when prompting for this value
 
@@ -63,7 +63,7 @@ The message to show when prompting for this value
 
 > `optional` **required**: `boolean`
 
-Defined in: [types/fabr-config.ts:43](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L43)
+Defined in: [types/fabr-config.ts:43](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L43)
 
 Whether this placeholder is required
 
@@ -73,7 +73,7 @@ Whether this placeholder is required
 
 > `optional` **transform**: [`PlaceholderTransform`](/fabr/docs/api/types/fabr-config/interfaces/placeholdertransform/)
 
-Defined in: [types/fabr-config.ts:45](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L45)
+Defined in: [types/fabr-config.ts:45](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L45)
 
 Transform this placeholder's value from another placeholder
 
@@ -83,6 +83,6 @@ Transform this placeholder's value from another placeholder
 
 > `optional` **validate**: [`PlaceholderValidation`](/fabr/docs/api/types/fabr-config/interfaces/placeholdervalidation/)
 
-Defined in: [types/fabr-config.ts:49](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L49)
+Defined in: [types/fabr-config.ts:49](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L49)
 
 Validation rules for this placeholder

--- a/website/src/content/docs/docs/api/types/fabr-config/interfaces/PlaceholderDefaultCase.md
+++ b/website/src/content/docs/docs/api/types/fabr-config/interfaces/PlaceholderDefaultCase.md
@@ -5,7 +5,7 @@ prev: false
 title: "PlaceholderDefaultCase"
 ---
 
-Defined in: [types/fabr-config.ts:24](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L24)
+Defined in: [types/fabr-config.ts:24](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L24)
 
 ## Properties
 
@@ -13,7 +13,7 @@ Defined in: [types/fabr-config.ts:24](https://github.com/yashjawale/fabr/blob/f0
 
 > **case**: [`CaseType`](/fabr/docs/api/types/fabr-config/type-aliases/casetype/)
 
-Defined in: [types/fabr-config.ts:28](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L28)
+Defined in: [types/fabr-config.ts:28](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L28)
 
 The case transformation to apply
 
@@ -23,7 +23,7 @@ The case transformation to apply
 
 > **source**: `string`
 
-Defined in: [types/fabr-config.ts:26](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L26)
+Defined in: [types/fabr-config.ts:26](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L26)
 
 The source placeholder key to transform from
 
@@ -33,6 +33,6 @@ The source placeholder key to transform from
 
 > `optional` **template**: `string`
 
-Defined in: [types/fabr-config.ts:30](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L30)
+Defined in: [types/fabr-config.ts:30](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L30)
 
 Template string where {value} will be replaced with the transformed value

--- a/website/src/content/docs/docs/api/types/fabr-config/interfaces/PlaceholderTransform.md
+++ b/website/src/content/docs/docs/api/types/fabr-config/interfaces/PlaceholderTransform.md
@@ -5,7 +5,7 @@ prev: false
 title: "PlaceholderTransform"
 ---
 
-Defined in: [types/fabr-config.ts:17](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L17)
+Defined in: [types/fabr-config.ts:17](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L17)
 
 ## Properties
 
@@ -13,7 +13,7 @@ Defined in: [types/fabr-config.ts:17](https://github.com/yashjawale/fabr/blob/f0
 
 > **case**: [`CaseType`](/fabr/docs/api/types/fabr-config/type-aliases/casetype/)
 
-Defined in: [types/fabr-config.ts:21](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L21)
+Defined in: [types/fabr-config.ts:21](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L21)
 
 The case transformation to apply
 
@@ -23,6 +23,6 @@ The case transformation to apply
 
 > **source**: `string`
 
-Defined in: [types/fabr-config.ts:19](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L19)
+Defined in: [types/fabr-config.ts:19](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L19)
 
 The source placeholder key to transform from

--- a/website/src/content/docs/docs/api/types/fabr-config/interfaces/PlaceholderValidation.md
+++ b/website/src/content/docs/docs/api/types/fabr-config/interfaces/PlaceholderValidation.md
@@ -5,7 +5,7 @@ prev: false
 title: "PlaceholderValidation"
 ---
 
-Defined in: [types/fabr-config.ts:8](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L8)
+Defined in: [types/fabr-config.ts:8](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L8)
 
 ## Properties
 
@@ -13,7 +13,7 @@ Defined in: [types/fabr-config.ts:8](https://github.com/yashjawale/fabr/blob/f01
 
 > `optional` **maxLength**: `number`
 
-Defined in: [types/fabr-config.ts:14](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L14)
+Defined in: [types/fabr-config.ts:14](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L14)
 
 Maximum length of the value
 
@@ -23,7 +23,7 @@ Maximum length of the value
 
 > `optional` **minLength**: `number`
 
-Defined in: [types/fabr-config.ts:12](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L12)
+Defined in: [types/fabr-config.ts:12](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L12)
 
 Minimum length of the value
 
@@ -33,6 +33,6 @@ Minimum length of the value
 
 > `optional` **pattern**: `string`
 
-Defined in: [types/fabr-config.ts:10](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L10)
+Defined in: [types/fabr-config.ts:10](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L10)
 
 Regular expression pattern that the value must match

--- a/website/src/content/docs/docs/api/types/fabr-config/type-aliases/CaseType.md
+++ b/website/src/content/docs/docs/api/types/fabr-config/type-aliases/CaseType.md
@@ -7,7 +7,7 @@ title: "CaseType"
 
 > **CaseType** = `"kebab"` \| `"pascal"` \| `"camel"` \| `"snake"` \| `"constant"`
 
-Defined in: [types/fabr-config.ts:6](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/fabr-config.ts#L6)
+Defined in: [types/fabr-config.ts:6](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/fabr-config.ts#L6)
 
 TypeScript interfaces for Fabr configuration
 Generated from fabr.config.schema.json

--- a/website/src/content/docs/docs/api/types/subcommand/classes/BaseSubcommand.md
+++ b/website/src/content/docs/docs/api/types/subcommand/classes/BaseSubcommand.md
@@ -5,7 +5,7 @@ prev: false
 title: "BaseSubcommand"
 ---
 
-Defined in: [types/subcommand.ts:25](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/subcommand.ts#L25)
+Defined in: [types/subcommand.ts:25](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/subcommand.ts#L25)
 
 Base class for implementing subcommands with consistent structure.
 Provides a common framework for command parsing, help display, and execution.
@@ -45,7 +45,7 @@ Implements the SubcommandDefinition interface with standardized behavior.
 
 > `abstract` **execute**(`templates`, `args`): `Promise`\<`void`\>
 
-Defined in: [types/subcommand.ts:69](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/subcommand.ts#L69)
+Defined in: [types/subcommand.ts:69](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/subcommand.ts#L69)
 
 Execute the command with parsed arguments.
 Must be implemented by subclass to provide the command's functionality.
@@ -80,7 +80,7 @@ Promise that resolves when command execution is complete
 
 > **handle**(`templates`, `rawArgs`): `Promise`\<`void`\>
 
-Defined in: [types/subcommand.ts:94](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/subcommand.ts#L94)
+Defined in: [types/subcommand.ts:94](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/subcommand.ts#L94)
 
 Main handler that follows the common command pattern.
 Orchestrates the command execution workflow:
@@ -114,7 +114,7 @@ Promise that resolves when command handling is complete
 
 > `abstract` **parseArgs**(`args`): `T`
 
-Defined in: [types/subcommand.ts:58](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/subcommand.ts#L58)
+Defined in: [types/subcommand.ts:58](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/subcommand.ts#L58)
 
 Parse command line arguments for this specific command.
 Must be implemented by subclass to handle command-specific argument parsing.
@@ -143,7 +143,7 @@ Parsed arguments object extending SubcommandArgs
 
 > **showHelp**(): `void`
 
-Defined in: [types/subcommand.ts:77](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/subcommand.ts#L77)
+Defined in: [types/subcommand.ts:77](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/subcommand.ts#L77)
 
 Show help for this command using the help content configuration.
 Uses the getHelpContent() method to format and display help information.
@@ -162,7 +162,7 @@ Uses the getHelpContent() method to format and display help information.
 
 > `abstract` `readonly` **description**: `string`
 
-Defined in: [types/subcommand.ts:38](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/subcommand.ts#L38)
+Defined in: [types/subcommand.ts:38](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/subcommand.ts#L38)
 
 Command description - must be implemented by subclass.
 A brief description of what the command does, used in help text.
@@ -177,7 +177,7 @@ A brief description of what the command does, used in help text.
 
 > `abstract` `readonly` **name**: `string`
 
-Defined in: [types/subcommand.ts:32](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/subcommand.ts#L32)
+Defined in: [types/subcommand.ts:32](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/subcommand.ts#L32)
 
 Command name - must be implemented by subclass.
 This should be the string used to invoke the command from the CLI.

--- a/website/src/content/docs/docs/api/types/subcommand/interfaces/SubcommandArgs.md
+++ b/website/src/content/docs/docs/api/types/subcommand/interfaces/SubcommandArgs.md
@@ -5,7 +5,7 @@ prev: false
 title: "SubcommandArgs"
 ---
 
-Defined in: [types/subcommand.ts:8](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/subcommand.ts#L8)
+Defined in: [types/subcommand.ts:8](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/subcommand.ts#L8)
 
 ## Extended by
 
@@ -17,4 +17,4 @@ Defined in: [types/subcommand.ts:8](https://github.com/yashjawale/fabr/blob/f01b
 
 > **help**: `boolean`
 
-Defined in: [types/subcommand.ts:9](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/subcommand.ts#L9)
+Defined in: [types/subcommand.ts:9](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/subcommand.ts#L9)

--- a/website/src/content/docs/docs/api/types/subcommand/interfaces/SubcommandDefinition.md
+++ b/website/src/content/docs/docs/api/types/subcommand/interfaces/SubcommandDefinition.md
@@ -5,7 +5,7 @@ prev: false
 title: "SubcommandDefinition"
 ---
 
-Defined in: [types/subcommand.ts:12](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/subcommand.ts#L12)
+Defined in: [types/subcommand.ts:12](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/subcommand.ts#L12)
 
 ## Type Parameters
 
@@ -19,7 +19,7 @@ Defined in: [types/subcommand.ts:12](https://github.com/yashjawale/fabr/blob/f01
 
 > **description**: `string`
 
-Defined in: [types/subcommand.ts:14](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/subcommand.ts#L14)
+Defined in: [types/subcommand.ts:14](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/subcommand.ts#L14)
 
 ***
 
@@ -27,7 +27,7 @@ Defined in: [types/subcommand.ts:14](https://github.com/yashjawale/fabr/blob/f01
 
 > **execute**: (`templates`, `args`) => `Promise`\<`void`\>
 
-Defined in: [types/subcommand.ts:17](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/subcommand.ts#L17)
+Defined in: [types/subcommand.ts:17](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/subcommand.ts#L17)
 
 #### Parameters
 
@@ -49,7 +49,7 @@ Defined in: [types/subcommand.ts:17](https://github.com/yashjawale/fabr/blob/f01
 
 > **name**: `string`
 
-Defined in: [types/subcommand.ts:13](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/subcommand.ts#L13)
+Defined in: [types/subcommand.ts:13](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/subcommand.ts#L13)
 
 ***
 
@@ -57,7 +57,7 @@ Defined in: [types/subcommand.ts:13](https://github.com/yashjawale/fabr/blob/f01
 
 > **parseArgs**: (`args`) => `T`
 
-Defined in: [types/subcommand.ts:15](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/subcommand.ts#L15)
+Defined in: [types/subcommand.ts:15](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/subcommand.ts#L15)
 
 #### Parameters
 
@@ -75,7 +75,7 @@ Defined in: [types/subcommand.ts:15](https://github.com/yashjawale/fabr/blob/f01
 
 > **showHelp**: () => `void`
 
-Defined in: [types/subcommand.ts:16](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/subcommand.ts#L16)
+Defined in: [types/subcommand.ts:16](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/subcommand.ts#L16)
 
 #### Returns
 

--- a/website/src/content/docs/docs/api/types/templates/functions/findTemplateBySlug.md
+++ b/website/src/content/docs/docs/api/types/templates/functions/findTemplateBySlug.md
@@ -5,9 +5,9 @@ prev: false
 title: "findTemplateBySlug"
 ---
 
-> **findTemplateBySlug**(`templates`, `slug`): `undefined` \| [`Template`](/fabr/docs/api/types/templates/interfaces/template/)
+> **findTemplateBySlug**(`templates`, `slug`): [`Template`](/fabr/docs/api/types/templates/interfaces/template/) \| `undefined`
 
-Defined in: [types/templates.ts:33](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/templates.ts#L33)
+Defined in: [types/templates.ts:33](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/templates.ts#L33)
 
 Find a template by its slug from an array of templates.
 Performs a linear search through the templates array to find a matching slug.
@@ -28,6 +28,6 @@ The slug to search for
 
 ## Returns
 
-`undefined` \| [`Template`](/fabr/docs/api/types/templates/interfaces/template/)
+[`Template`](/fabr/docs/api/types/templates/interfaces/template/) \| `undefined`
 
 The matching template object, or undefined if not found

--- a/website/src/content/docs/docs/api/types/templates/functions/getTemplateSlugs.md
+++ b/website/src/content/docs/docs/api/types/templates/functions/getTemplateSlugs.md
@@ -7,7 +7,7 @@ title: "getTemplateSlugs"
 
 > **getTemplateSlugs**(`templates`): `string`[]
 
-Defined in: [types/templates.ts:45](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/templates.ts#L45)
+Defined in: [types/templates.ts:45](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/templates.ts#L45)
 
 Extract all template slugs from an array of templates.
 Returns an array containing just the slug values from all templates.

--- a/website/src/content/docs/docs/api/types/templates/functions/isValidTemplateSlug.md
+++ b/website/src/content/docs/docs/api/types/templates/functions/isValidTemplateSlug.md
@@ -7,7 +7,7 @@ title: "isValidTemplateSlug"
 
 > **isValidTemplateSlug**(`templates`, `slug`): `boolean`
 
-Defined in: [types/templates.ts:58](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/templates.ts#L58)
+Defined in: [types/templates.ts:58](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/templates.ts#L58)
 
 Validate that a template slug exists in the templates array.
 Checks if any template in the provided array has the specified slug.

--- a/website/src/content/docs/docs/api/types/templates/functions/validateTemplatesConfig.md
+++ b/website/src/content/docs/docs/api/types/templates/functions/validateTemplatesConfig.md
@@ -7,7 +7,7 @@ title: "validateTemplatesConfig"
 
 > **validateTemplatesConfig**(`config`): `config is TemplatesConfig`
 
-Defined in: [types/templates.ts:75](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/templates.ts#L75)
+Defined in: [types/templates.ts:75](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/templates.ts#L75)
 
 Validate templates configuration structure and content.
 Performs comprehensive validation of a templates configuration object:

--- a/website/src/content/docs/docs/api/types/templates/interfaces/Template.md
+++ b/website/src/content/docs/docs/api/types/templates/interfaces/Template.md
@@ -5,7 +5,7 @@ prev: false
 title: "Template"
 ---
 
-Defined in: [types/templates.ts:6](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/templates.ts#L6)
+Defined in: [types/templates.ts:6](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/templates.ts#L6)
 
 TypeScript interfaces for Fabr templates configuration
 Generated from templates.schema.json
@@ -16,7 +16,7 @@ Generated from templates.schema.json
 
 > **name**: `string`
 
-Defined in: [types/templates.ts:8](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/templates.ts#L8)
+Defined in: [types/templates.ts:8](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/templates.ts#L8)
 
 Display name of the template
 
@@ -26,7 +26,7 @@ Display name of the template
 
 > **repo**: `string`
 
-Defined in: [types/templates.ts:12](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/templates.ts#L12)
+Defined in: [types/templates.ts:12](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/templates.ts#L12)
 
 GitHub repository (owner/repo format) or full URL
 
@@ -36,6 +36,6 @@ GitHub repository (owner/repo format) or full URL
 
 > **slug**: `string`
 
-Defined in: [types/templates.ts:10](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/templates.ts#L10)
+Defined in: [types/templates.ts:10](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/templates.ts#L10)
 
 Unique identifier for the template

--- a/website/src/content/docs/docs/api/types/templates/interfaces/TemplatesConfig.md
+++ b/website/src/content/docs/docs/api/types/templates/interfaces/TemplatesConfig.md
@@ -5,7 +5,7 @@ prev: false
 title: "TemplatesConfig"
 ---
 
-Defined in: [types/templates.ts:15](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/templates.ts#L15)
+Defined in: [types/templates.ts:15](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/templates.ts#L15)
 
 ## Properties
 
@@ -13,7 +13,7 @@ Defined in: [types/templates.ts:15](https://github.com/yashjawale/fabr/blob/f01b
 
 > `optional` **$schema**: `string`
 
-Defined in: [types/templates.ts:17](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/templates.ts#L17)
+Defined in: [types/templates.ts:17](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/templates.ts#L17)
 
 JSON Schema reference
 
@@ -23,7 +23,7 @@ JSON Schema reference
 
 > `optional` **defaultTemplate**: `string`
 
-Defined in: [types/templates.ts:21](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/templates.ts#L21)
+Defined in: [types/templates.ts:21](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/templates.ts#L21)
 
 The default template to select (must match a template slug)
 
@@ -33,6 +33,6 @@ The default template to select (must match a template slug)
 
 > **templates**: [`Template`](/fabr/docs/api/types/templates/interfaces/template/)[]
 
-Defined in: [types/templates.ts:19](https://github.com/yashjawale/fabr/blob/f01b72cf78714226de776336ec5f87a5b71f2c78/src/types/templates.ts#L19)
+Defined in: [types/templates.ts:19](https://github.com/yashjawale/fabr/blob/2175f836f52904c60bea5117c14ee0416e76bd93/src/types/templates.ts#L19)
 
 Array of available project templates

--- a/website/src/content/docs/docs/getting-started/cli-reference.md
+++ b/website/src/content/docs/docs/getting-started/cli-reference.md
@@ -1,0 +1,289 @@
+---
+title: Get to Know the CLI
+description: Complete reference of fabr CLI commands with usage examples and options
+---
+
+Fabr provides a simple yet powerful command-line interface with five main commands. Each command is designed to be intuitive and follows consistent patterns for options and arguments.
+
+## Command Overview
+
+| Command | Purpose | Example |
+|---------|---------|---------|
+| `init` | Create a new project from a template | `npx fabr init my-project` |
+| `list` | List all available templates | `npx fabr list` |
+| `search` | Search templates by keywords | `npx fabr search react` |
+| `help` | Show help information | `npx fabr help` |
+| `version` | Show version information | `npx fabr version` |
+
+## Global Options
+
+These options work with any command:
+
+- `--help, -h` - Show help for the command
+- `--version, -v` - Show version information (works globally)
+
+## Command Details
+
+### `init` - Create New Project
+
+The main command for creating projects from templates.
+
+**Usage:**
+```bash
+npx fabr init [project-name] [options]
+```
+
+**Arguments:**
+- `project-name` - Name of the project directory to create (optional, will prompt if not provided)
+
+**Options:**
+- `--template=<slug>` or `-t <slug>` - Template slug to use (skips template selection)
+- `--help, -h` - Show help message
+
+**Examples:**
+
+```bash
+# Interactive mode - prompts for everything
+npx fabr init
+
+# Specify project name, choose template interactively
+npx fabr init my-awesome-project
+
+# Specify both project name and template
+npx fabr init my-react-app --template=react-app
+
+# Short form for template option
+npx fabr init my-site -t static-site
+
+# Get help for the init command
+npx fabr init --help
+```
+
+**What happens when you run init:**
+
+1. **Project name validation** - Checks if the name is valid and suggests alternatives if needed
+2. **Template selection** - Shows available templates or uses the one specified
+3. **Project details** - Prompts for placeholders like author name, description, etc.
+4. **Template download** - Downloads the template from GitHub using degit
+5. **Configuration processing** - Reads `fabr.config.json` if present
+6. **Placeholder replacement** - Replaces `{{PLACEHOLDER}}` patterns in files
+7. **Command execution** - Runs setup commands for command-based templates
+8. **Environment setup** - Creates `.env` files if configured
+9. **Dependency installation** - Runs install commands like `npm install`
+10. **Cleanup** - Removes template configuration files
+
+### `list` - Show Available Templates
+
+Display all available templates with their details.
+
+**Usage:**
+```bash
+npx fabr list [options]
+```
+
+**Options:**
+- `--help, -h` - Show help message
+
+**Examples:**
+
+```bash
+# List all templates
+npx fabr list
+
+# Get help for the list command
+npx fabr list --help
+```
+
+**Output example:**
+```
+Available Templates:
+
+1. React Application
+   Slug: react-app
+   Repository: fabr-templates/react-typescript
+
+2. Node.js Server
+   Slug: node-server
+   Repository: fabr-templates/express-server
+
+Total: 2 templates available
+```
+
+### `search` - Find Templates
+
+Search through available templates by name, slug, or repository.
+
+**Usage:**
+```bash
+npx fabr search <query> [options]
+```
+
+**Arguments:**
+- `query` - Search terms to look for
+
+**Options:**
+- `--exact` - Search for exact matches only
+- `--case` - Case-sensitive search
+- `--help, -h` - Show help message
+
+**Examples:**
+
+```bash
+# Basic search (case-insensitive, partial matches)
+npx fabr search react
+
+# Search for exact matches only
+npx fabr search --exact chrome-ext
+
+# Case-sensitive search
+npx fabr search TypeScript --case
+
+# Search with multiple words
+npx fabr search "next js"
+
+# Show all templates (no query)
+npx fabr search
+
+# Get help for the search command
+npx fabr search --help
+```
+
+**Output example:**
+```
+Search Results
+Query: "react"
+
+1. React Application
+   Slug: react-app
+   Repository: fabr-templates/react-typescript
+   Owner: fabr-templates
+   Project: react-typescript
+
+Found 1 template matching "react"
+
+To create a project, use: npx fabr init <project-name> --template=<slug>
+```
+
+### `help` - Get Help
+
+Show global help information or help for specific commands.
+
+**Usage:**
+```bash
+npx fabr help
+```
+
+**Examples:**
+
+```bash
+# Show global help
+npx fabr help
+
+# Show help for specific commands
+npx fabr init --help
+npx fabr list --help
+npx fabr search --help
+```
+
+**The help command shows:**
+- Usage instructions
+- Available commands overview
+- Global options
+- Common examples
+- ASCII art logo
+
+### `version` - Show Version
+
+Display the current version of fabr.
+
+**Usage:**
+```bash
+npx fabr version
+```
+
+**Examples:**
+
+```bash
+# Show version
+npx fabr version
+
+# Alternative using global flag
+npx fabr --version
+npx fabr -v
+```
+
+**Output example:**
+```
+fabr v1.2.3
+```
+
+## Common Workflows
+
+### Quick Project Creation
+
+If you know what you want:
+
+```bash
+# Create a React project
+npx fabr init my-app -t react-app
+
+# Create a Node.js server
+npx fabr init my-api -t node-server
+```
+
+### Exploring Templates
+
+When you're not sure what's available:
+
+```bash
+# See all templates
+npx fabr list
+
+# Search for specific technology
+npx fabr search vue
+npx fabr search typescript
+
+# Create project interactively
+npx fabr init
+```
+
+### Getting Help
+
+When you need assistance:
+
+```bash
+# General help
+npx fabr help
+
+# Command-specific help
+npx fabr init --help
+npx fabr search --help
+
+# Check version
+npx fabr version
+```
+
+## Error Handling
+
+Fabr provides helpful error messages and suggestions:
+
+- **Invalid project names** - Suggests valid alternatives
+- **Missing templates** - Shows available options
+- **Missing arguments** - Prompts for required information
+- **Network issues** - Clear error messages for download failures
+
+## Tips and Best Practices
+
+1. **Use descriptive project names** - Helps organize your projects
+2. **Explore templates first** - Use `list` and `search` to find the right template
+3. **Specify templates when scripting** - Use `-t` flag for automation
+4. **Check version compatibility** - Use `version` command to ensure you're up to date
+5. **Read template documentation** - Many templates have additional setup instructions
+
+## Next Steps
+
+Now that you know the CLI commands:
+
+- Try the [Quick Start guide](/getting-started/quick-start) to create your first project
+- Learn about [template types](/templates/overview) to understand how they work
+- Explore [creating your own templates](/contributing/templates) to share your setups

--- a/website/src/content/docs/docs/getting-started/cli-reference.md
+++ b/website/src/content/docs/docs/getting-started/cli-reference.md
@@ -7,13 +7,13 @@ Fabr provides a simple yet powerful command-line interface with five main comman
 
 ## Command Overview
 
-| Command | Purpose | Example |
-|---------|---------|---------|
-| `init` | Create a new project from a template | `npx fabr init my-project` |
-| `list` | List all available templates | `npx fabr list` |
-| `search` | Search templates by keywords | `npx fabr search react` |
-| `help` | Show help information | `npx fabr help` |
-| `version` | Show version information | `npx fabr version` |
+| Command   | Purpose                              | Example                    |
+| --------- | ------------------------------------ | -------------------------- |
+| `init`    | Create a new project from a template | `npx fabr init my-project` |
+| `list`    | List all available templates         | `npx fabr list`            |
+| `search`  | Search templates by keywords         | `npx fabr search react`    |
+| `help`    | Show help information                | `npx fabr help`            |
+| `version` | Show version information             | `npx fabr version`         |
 
 ## Global Options
 
@@ -29,14 +29,17 @@ These options work with any command:
 The main command for creating projects from templates.
 
 **Usage:**
+
 ```bash
 npx fabr init [project-name] [options]
 ```
 
 **Arguments:**
+
 - `project-name` - Name of the project directory to create (optional, will prompt if not provided)
 
 **Options:**
+
 - `--template=<slug>` or `-t <slug>` - Template slug to use (skips template selection)
 - `--help, -h` - Show help message
 
@@ -77,11 +80,13 @@ npx fabr init --help
 Display all available templates with their details.
 
 **Usage:**
+
 ```bash
 npx fabr list [options]
 ```
 
 **Options:**
+
 - `--help, -h` - Show help message
 
 **Examples:**
@@ -95,6 +100,7 @@ npx fabr list --help
 ```
 
 **Output example:**
+
 ```
 Available Templates:
 
@@ -114,14 +120,17 @@ Total: 2 templates available
 Search through available templates by name, slug, or repository.
 
 **Usage:**
+
 ```bash
 npx fabr search <query> [options]
 ```
 
 **Arguments:**
+
 - `query` - Search terms to look for
 
 **Options:**
+
 - `--exact` - Search for exact matches only
 - `--case` - Case-sensitive search
 - `--help, -h` - Show help message
@@ -149,6 +158,7 @@ npx fabr search --help
 ```
 
 **Output example:**
+
 ```
 Search Results
 Query: "react"
@@ -169,6 +179,7 @@ To create a project, use: npx fabr init <project-name> --template=<slug>
 Show global help information or help for specific commands.
 
 **Usage:**
+
 ```bash
 npx fabr help
 ```
@@ -186,6 +197,7 @@ npx fabr search --help
 ```
 
 **The help command shows:**
+
 - Usage instructions
 - Available commands overview
 - Global options
@@ -197,6 +209,7 @@ npx fabr search --help
 Display the current version of fabr.
 
 **Usage:**
+
 ```bash
 npx fabr version
 ```
@@ -213,6 +226,7 @@ npx fabr -v
 ```
 
 **Output example:**
+
 ```
 fabr v1.2.3
 ```


### PR DESCRIPTION
This pull request primarily updates the documentation for the CLI commands to reference the latest source code commit and adds a new introductory CLI reference page to the website navigation. The changes ensure that all API and class documentation links point to the most current codebase, improving accuracy and maintainability for developers referencing the docs.

Documentation improvements:

* Updated all "Defined in" source links in CLI command documentation files to point to the latest commit (`2175f836f52904c60bea5117c14ee0416e76bd93`) for accurate code references in files such as `commands/index.ts`, `commands/help.ts`, `commands/init.ts`, `commands/list.ts`, and `types/subcommand.ts`. [[1]](diffhunk://#diff-25f5e9c3e66a4cecf6ba0945ee8d1b9f95e4b5e92b069ac64f2082d77780fe1eL10-R10) [[2]](diffhunk://#diff-42b78b62fb78c7dd82c972d3b0502c478902f89df442629bbb8f69e30aca4415L10-R10) [[3]](diffhunk://#diff-65b94844cea8ecb20fc41da09133faa444bb0a5fd334eafd0bef323867fbfb81L8-R8) [[4]](diffhunk://#diff-65b94844cea8ecb20fc41da09133faa444bb0a5fd334eafd0bef323867fbfb81L36-R36) [[5]](diffhunk://#diff-65b94844cea8ecb20fc41da09133faa444bb0a5fd334eafd0bef323867fbfb81L57-R57) [[6]](diffhunk://#diff-65b94844cea8ecb20fc41da09133faa444bb0a5fd334eafd0bef323867fbfb81L95-R95) [[7]](diffhunk://#diff-65b94844cea8ecb20fc41da09133faa444bb0a5fd334eafd0bef323867fbfb81L124-R124) [[8]](diffhunk://#diff-65b94844cea8ecb20fc41da09133faa444bb0a5fd334eafd0bef323867fbfb81L143-R143) [[9]](diffhunk://#diff-65b94844cea8ecb20fc41da09133faa444bb0a5fd334eafd0bef323867fbfb81L158-R158) [[10]](diffhunk://#diff-0621cc82a0d5f298623630e8fe61d501a29592c0e9612aae4b760812a551e277L10-R10) [[11]](diffhunk://#diff-15b5a0f7994098f364b8f2a76b77f30b7c6506596ccf0d3455b572fba41f279bL8-R8) [[12]](diffhunk://#diff-15b5a0f7994098f364b8f2a76b77f30b7c6506596ccf0d3455b572fba41f279bL36-R36) [[13]](diffhunk://#diff-15b5a0f7994098f364b8f2a76b77f30b7c6506596ccf0d3455b572fba41f279bL80-R80) [[14]](diffhunk://#diff-15b5a0f7994098f364b8f2a76b77f30b7c6506596ccf0d3455b572fba41f279bL118-R118) [[15]](diffhunk://#diff-15b5a0f7994098f364b8f2a76b77f30b7c6506596ccf0d3455b572fba41f279bL147-R147) [[16]](diffhunk://#diff-15b5a0f7994098f364b8f2a76b77f30b7c6506596ccf0d3455b572fba41f279bL166-R166) [[17]](diffhunk://#diff-15b5a0f7994098f364b8f2a76b77f30b7c6506596ccf0d3455b572fba41f279bL181-R181) [[18]](diffhunk://#diff-a771628dd99cd93012ffd2e48ce2fd2211f56bb5c40211ea09c88a1d4f7c08f4L8-R8) [[19]](diffhunk://#diff-a771628dd99cd93012ffd2e48ce2fd2211f56bb5c40211ea09c88a1d4f7c08f4L20-R20) [[20]](diffhunk://#diff-a771628dd99cd93012ffd2e48ce2fd2211f56bb5c40211ea09c88a1d4f7c08f4L32-R40) [[21]](diffhunk://#diff-34cb7b3ad9e8d79629d51e942b668965a19af77dd070753c41cf17a958018686L8-R32) [[22]](diffhunk://#diff-eebdec04f1ef0ab41940842628dcac051ded2f42cfe7ab86925ba300e9f2e425L8-R8) [[23]](diffhunk://#diff-eebdec04f1ef0ab41940842628dcac051ded2f42cfe7ab86925ba300e9f2e425L36-R36) [[24]](diffhunk://#diff-eebdec04f1ef0ab41940842628dcac051ded2f42cfe7ab86925ba300e9f2e425L66-R66) [[25]](diffhunk://#diff-eebdec04f1ef0ab41940842628dcac051ded2f42cfe7ab86925ba300e9f2e425L104-R104) [[26]](diffhunk://#diff-eebdec04f1ef0ab41940842628dcac051ded2f42cfe7ab86925ba300e9f2e425L133-R133)

Navigation update:

* Added a new "Get to know the CLI" entry to the website navigation under "Getting Started" to improve discoverability of CLI documentation.